### PR TITLE
responseの文頭の無駄なコメントに対応

### DIFF
--- a/lib/yahoo/api/response.rb
+++ b/lib/yahoo/api/response.rb
@@ -6,7 +6,7 @@ module Yahoo
       @response =response
       body = @response.body
       if format == "json"
-        body = body[9..(body.rindex(")")-1)] if body.include?("callback(")
+        body = body[(body.index("(")+1)..(body.rindex(")")-1)] if body.include?("callback(")
         @body = JSON.parse(body)
       else
         @body = Hash.from_xml(body)


### PR DESCRIPTION
resopnseの文頭に無駄なコメントがつくようになったので、

`/**/callback({\"ResultSet\":{...`

文頭の部分文字列削除を、最初の"("までに変更しました。
